### PR TITLE
feature/update-README-for-3.3.0-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ CRA_PORT = 9999      # defaults to 3000
 
 ### 2. urls.py
 
-Hot-reloading support can be enabled by adding the following to your project or app's **urls.py** file:
+Hot-reloading support can be enabled by first adding the following to your project or app's **urls.py** file:
 
 ```python
 # import Django settings
@@ -115,12 +115,37 @@ urlpatterns = [...]
 # add a reverse-proxy view to help React in the Django view talk to Create-React-App
 if settings.DEBUG:
     proxy_urls = [
-        re_path(r'^sockjs-node/(?P<path>.*)$', proxy_cra_requests),
         re_path(r'^__webpack_dev_server__/(?P<path>.*)$', proxy_cra_requests),
     ]
     urlpatterns.extend(proxy_urls)
-
 ```
+
+Next, follow the instructions below that correspond to your project's version of `react-scripts`:
+
+<details>
+  <summary>For projects using <strong>react-scripts@&lt;3.3.0</strong></summary>
+
+  Add one more url to `proxy_urls` above:
+
+  ```python
+  proxy_urls = [
+      # ...snip...
+      re_path(r'^sockjs-node/(?P<path>.*)$', proxy_cra_requests),
+  ]
+  ```
+</details>
+
+<br>
+
+<details>
+  <summary>For projects using <strong>react-scripts@&gt;=3.3.0</strong></summary>
+
+  Create an **.env** file in the root of your Create-React-App folder with the following environment variable:
+
+  ```
+  WDS_SOCKET_PORT=3000
+  ```
+</details>
 
 ### 3. asset-manifest.json
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- omit in toc -->
 # django-cra-helper
 
 [![PyPI version](https://badge.fury.io/py/django-cra-helper.svg)](https://pypi.org/project/django-cra-helper/)
@@ -10,14 +11,10 @@
   - [3. asset-manifest.json](#3-asset-manifestjson)
 - [Development](#development)
 - [Production](#production)
-  - [For older projects using up through `react-scripts@2.1.8`](#for-older-projects-using-up-through-react-scripts218)
-  - [For projects using `react-scripts@3.0.0` to `react-scripts@3.1.2`](#for-projects-using-react-scripts300-to-react-scripts312)
-  - [For projects using `react-scripts@3.2.0` on](#for-projects-using-react-scripts320-on)
 - [React in Django templates](#react-in-django-templates)
   - [Specifying React Components via template context](#specifying-react-components-via-template-context)
   - [Referencing React static files](#referencing-react-static-files)
 - [The Payoff Revealed](#the-payoff-revealed)
-- [TODO](#todo)
 
 ## Introduction
 
@@ -384,8 +381,3 @@ For example, a **logo.svg** file in the CRA project can be included in a Django 
 When all is said and done, React components should now render and be viewable in both the CRA liveserver and when served via Django. Here's an example of a slightly-modified CRA `App` component displayed in CRA (left) and Django (right):
 
 ![Comparison Shot](./side_by_side.png)
-
-## TODO
-
-* ~~Figure out how to get Django to auto-reload when the CRA liveserver reloads after code is updated.~~
-  * Supported as of v1.2.0

--- a/README.md
+++ b/README.md
@@ -186,57 +186,69 @@ python manage.py collectstatic --no-input
 
 React assets will be included with the other static assets in the `settings.STATIC_ROOT` directory, to be served as is usual in a Django production environment. An `asset-manifest.json` file will also get pulled in. The contents of this CRA-generated file are required by **django-cra-helper** to help reference React files that have had a unique hash added to their filenames during the build process.
 
-Similar to the `bundle_js` template variable mentioned earlier, **django-cra-helper** includes numerous other template variables when the CRA liveserver is _not_ running.
+Similar to the `bundle_js` template variable mentioned earlier, **django-cra-helper** includes numerous other template variables when the CRA liveserver is _not_ running:
 
-### For older projects using up through `react-scripts@2.1.8`
+<details>
+  <summary>For older projects using <strong>react-scripts@&lt;=2.1.8</strong></summary>
 
-The two most important variables are `main_js` and `main_css`. These can be injected into the page via a typical call to `{% static %}` in the template:
+  The two most important variables are `main_js` and `main_css`. These can be injected into the page via a typical call to `{% static %}` in the template:
 
-```html
-{% if main_css %}
-<link href="{% static main_css %}" rel="stylesheet">
-{% endif %}
-```
-```html
-{% if main_js %}
-<script type="text/javascript" src="{% static main_js %}"></script>
-{% endif %}
-```
+  ```html
+  {% if main_css %}
+  <link href="{% static main_css %}" rel="stylesheet">
+  {% endif %}
+  ```
+  ```html
+  {% if main_js %}
+  <script type="text/javascript" src="{% static main_js %}"></script>
+  {% endif %}
+  ```
 
-> NOTE: Recent attempts at building a fresh CRA project with `react-scripts@2.1.8` were unsuccessful in recreating SPAs that allowed for just a single `main_js`. `npm run build`-produced artifacts functioned almost identically to artifacts generated the same as `react-scripts@3.1.2`, detailed below.
->
-> There may be child dependencies of `react-scripts` that make it no longer possible to start apps that will function with the above instructions. In these cases, please try the instructions in the next section.
+  > NOTE: Recent attempts at building a fresh CRA project with `react-scripts@2.1.8` were unsuccessful in recreating SPAs that allowed for just a single `main_js`. `npm run build`-produced artifacts functioned almost identically to artifacts generated the same as `react-scripts@3.1.2`, detailed below.
+  >
+  > There may be child dependencies of `react-scripts` that make it no longer possible to start apps that will function with the above instructions. In these cases, please try the instructions in the next section.
+</details>
 
-### For projects using `react-scripts@3.0.0` to `react-scripts@3.1.2`
+<br>
 
-Code-splitting was introduced in later versions of `react-scripts` that split up `main_js` into multiple files. Additional `<script>` tags are required to enable the React project to load. Depending on the size of your project, in addition to `main_js` mentioned above you'll need to add at least two more in a specific order:
+<details>
+  <summary>For projects using <strong>react-scripts@&gt;=3.0.0 to react-scripts@&lt;3.2.0</strong></summary>
 
-```html
-{% if main_js %}
-<script type="text/javascript" src="{% static runtime_main_js %}"></script>
-<script type="text/javascript" src="{% static static_js_2_9a95e042_chunk_js %}"></script>
-<script type="text/javascript" src="{% static main_js %}"></script>
-{% endif %}
-```
+  Code-splitting was introduced in later versions of `react-scripts` that split up `main_js` into multiple files. Additional `<script>` tags are required to enable the React project to load. Depending on the size of your project, in addition to `main_js` mentioned above you'll need to add at least two more in a specific order:
 
-The naming of `static_js_2_9a95e042_chunk_js` above will differ from project to project. Unfortunately you'll have to manually confirm this value in your project's **asset-manifest.json** and update accordingly. It doesn't seem to change between builds, though, so it may not be a value you need to regularly update...
+  ```html
+  {% if main_js %}
+  <script type="text/javascript" src="{% static runtime_main_js %}"></script>
+  <script type="text/javascript" src="{% static static_js_2_9a95e042_chunk_js %}"></script>
+  <script type="text/javascript" src="{% static main_js %}"></script>
+  {% endif %}
+  ```
 
-### For projects using `react-scripts@3.2.0` on
+  The naming of `static_js_2_9a95e042_chunk_js` above will differ from project to project. Unfortunately you'll have to manually confirm this value in your project's **asset-manifest.json** and update accordingly. It doesn't seem to change between builds, though, so it may not be a value you need to regularly update...
+</details>
 
-Starting with `react-scripts@3.2.0`, a new `entrypoints` property can be found in **asset-manifest.json**. This contains an array of files that **django-cra-helper** makes available in templates to more easily inject these files via new `entrypoints.css` and `entrypoints.js` arrays. These **replace** the `main_css` and `main_js` values used above:
+<br>
 
-```html
-{% for file in entrypoints.css %}
-<link href="{% static file %}" rel="stylesheet">
-{% endfor %}
-```
-```html
-{% for file in entrypoints.js %}
-<script type="text/javascript" src="{% static file %}"></script>
-{% endfor %}
-```
+<details>
+  <summary>For projects using <strong>react-scripts@&gt;=3.2.0</strong></summary>
 
-> NOTE: These JavaScript and CSS files should be arranged in an order required for the site to load; the ultimate order is derived from the order present in **asset-manifest.json**.
+  Starting with `react-scripts@3.2.0`, a new `entrypoints` property can be found in **asset-manifest.json**. This contains an array of files that **django-cra-helper** makes available in templates to more easily inject these files via new `entrypoints.css` and `entrypoints.js` arrays. These **replace** the `main_css` and `main_js` values used above:
+
+  ```html
+  {% for file in entrypoints.css %}
+  <link href="{% static file %}" rel="stylesheet">
+  {% endfor %}
+  ```
+  ```html
+  {% for file in entrypoints.js %}
+  <script type="text/javascript" src="{% static file %}"></script>
+  {% endfor %}
+  ```
+
+  > NOTE: These JavaScript and CSS files should be arranged in an order required for the site to load; the ultimate order is derived from the order present in **asset-manifest.json**.
+</details>
+
+
 
 ## React in Django templates
 

--- a/README.md
+++ b/README.md
@@ -132,8 +132,6 @@ Next, follow the instructions below that correspond to your project's version of
   ```
 </details>
 
-<br>
-
 <details>
   <summary>For projects using <strong>react-scripts@&gt;=3.3.0</strong></summary>
 
@@ -206,8 +204,6 @@ Similar to the `bundle_js` template variable mentioned earlier, **django-cra-hel
   > There may be child dependencies of `react-scripts` that make it no longer possible to start apps that will function with the above instructions. In these cases, please try the instructions in the next section.
 </details>
 
-<br>
-
 <details>
   <summary>For projects using <strong>react-scripts@&gt;=3.0.0 to react-scripts@&lt;3.2.0</strong></summary>
 
@@ -223,8 +219,6 @@ Similar to the `bundle_js` template variable mentioned earlier, **django-cra-hel
 
   The naming of `static_js_2_9a95e042_chunk_js` above will differ from project to project. Unfortunately you'll have to manually confirm this value in your project's **asset-manifest.json** and update accordingly. It doesn't seem to change between builds, though, so it may not be a value you need to regularly update...
 </details>
-
-<br>
 
 <details>
   <summary>For projects using <strong>react-scripts@&gt;=3.2.0</strong></summary>


### PR DESCRIPTION
Starting with create-react-app@v3.3.0, `react-dev-utils` now uses native Websockets to establish a connection between the code running in the browser and the live server. This broke the `sockjs-node/` reverse proxy, preventing live-reloading from working within Django.

An alternative was identified while solving issue #6. This PR contains updates to README.md that include alternative instructions for enabling live-reloading with modern releases of create-react-app.